### PR TITLE
feat: Azure Container Apps deployment for tools/httpserver

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,0 +1,154 @@
+# Deploys tools/httpserver to Azure Container Apps. Runs only after merge to
+# master (never on a PR) - this pipeline provisions and updates real, billed
+# Azure infrastructure, so it stays out of the PR check gate. PR checks are
+# ci.yml / go.yml / security.yml / codeql.yml / e2e.yml, unchanged by this
+# file.
+#
+# One-time prerequisite (done once, outside this repo, in the Azure portal
+# or `az ad app create` / `az ad app federated-credential create`): an Azure
+# AD App Registration with a federated credential trusting GitHub OIDC for
+# this repo + the master branch, granted Contributor on the target
+# subscription/resource group. No client secret is stored anywhere - this is
+# exactly what azure/login's OIDC mode is for. Once created, set these as
+# repository variables (not secrets, they aren't sensitive on their own):
+#   AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+# And these as repository secrets:
+#   STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, ALERT_EMAIL
+#
+# Flow: deploy the Bicep stack first (it has a public placeholder default for
+# containerImage, so it stands up the ACR/Key Vault/environment/Container App
+# before a real image exists), then build+scan+push the real image to the
+# now-existing ACR, then point the running Container App at it with
+# `az containerapp update`. This avoids guessing the ACR's Bicep-computed
+# name from bash and creating a second, orphaned registry.
+
+name: Deploy to Azure Container Apps
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'infra/azure/**'
+      - 'tools/httpserver/**'
+      - 'governance/**'
+      - 'Dockerfile'
+      - '.github/workflows/deploy-azure.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  RESOURCE_GROUP: joltrin-prod-rg
+  LOCATION: eastus
+  CONTAINER_APP_NAME: joltrin-app
+  ACR_IMAGE_NAME: joltrin
+
+jobs:
+  deploy-infra:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      acr-login-server: ${{ steps.deploy.outputs.acrLoginServer }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC, no stored secret)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure resource group exists
+        run: az group create -n "$RESOURCE_GROUP" -l "$LOCATION" -o none
+
+      - name: Deploy Bicep stack (infra only; image stays whatever it already is)
+        id: deploy
+        run: |
+          az deployment group create \
+            -g "$RESOURCE_GROUP" \
+            -f infra/azure/main.bicep \
+            -p infra/azure/main.parameters.json \
+            -p alertEmail="${{ secrets.ALERT_EMAIL }}" \
+            -p stripeSecretKey="${{ secrets.STRIPE_SECRET_KEY }}" \
+            -p stripeWebhookSecret="${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
+            -o json > deploy-output.json
+          acr_login_server=$(jq -r '.properties.outputs.acrLoginServer.value' deploy-output.json)
+          echo "acrLoginServer=${acr_login_server}" >> "$GITHUB_OUTPUT"
+
+  build-scan-push:
+    needs: deploy-infra
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image-tag: ${{ steps.tag.outputs.image-tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          version=$(cat VERSION 2>/dev/null || echo "0.0.0")
+          echo "image-tag=${version}-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build runtime image
+        run: docker build --target runtime -t joltrin:scan .
+
+      # Same gate as .github/workflows/security.yml's image-scan job: block
+      # the push on any critical/high CVE in the image about to ship to
+      # production.
+      - name: Trivy image scan (block on critical/high)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: joltrin:scan
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+          format: table
+
+      - name: Azure login (OIDC, no stored secret)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Push image to ACR
+        run: |
+          az acr login --name "$(echo '${{ needs.deploy-infra.outputs.acr-login-server }}' | cut -d. -f1)"
+          docker tag joltrin:scan "${{ needs.deploy-infra.outputs.acr-login-server }}/${ACR_IMAGE_NAME}:${{ steps.tag.outputs.image-tag }}"
+          docker push "${{ needs.deploy-infra.outputs.acr-login-server }}/${ACR_IMAGE_NAME}:${{ steps.tag.outputs.image-tag }}"
+
+  roll-revision:
+    needs: [ deploy-infra, build-scan-push ]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Azure login (OIDC, no stored secret)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      # Container Apps' default revision mode is a rolling update: the new
+      # revision must pass its startup/readiness probes (see
+      # infra/azure/modules/container-app.bicep) before traffic shifts to
+      # it, and the prior revision stays healthy and serving until it does.
+      # `az containerapp update` blocks until the new revision reaches a
+      # terminal state, so a bad image/probe failure fails this step
+      # instead of silently going live.
+      - name: Point the Container App at the new image
+        run: |
+          az containerapp update \
+            -n "$CONTAINER_APP_NAME" \
+            -g "$RESOURCE_GROUP" \
+            --image "${{ needs.deploy-infra.outputs.acr-login-server }}/${ACR_IMAGE_NAME}:${{ needs.build-scan-push.outputs.image-tag }}"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -30,4 +30,9 @@ regexes = [
   '''remote-client-test-secret''',
   '''secret_password''',
   '''my-secret-token''',
+  # Well-known Azure built-in role definition IDs used in Bicep role
+  # assignments (AcrPull, Key Vault Secrets User). These are public,
+  # Microsoft-documented constants, not credentials.
+  '''7f951dda-4ed3-4680-a7ca-43fe172d538d''',
+  '''4633458b-17de-408a-b874-0445c86b69e6''',
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: security-scan lint-sec sast sca secrets-scan iac-scan
+.PHONY: security-scan lint-sec sast sca secrets-scan iac-scan lint-infra deploy-check
 
 # Mirrors the checks run in .github/workflows/security.yml and codeql.yml
 # so issues surface locally before a push, not after CI runs.
@@ -64,3 +64,38 @@ sast:
 
 security-scan: lint-sec sca secrets-scan iac-scan
 	@echo "All local security checks passed."
+
+# Mirrors the pre-deploy checks that should pass before touching Azure, so
+# issues surface locally before a push, not after deploy-azure.yml runs.
+
+lint-infra:
+	@if command -v az >/dev/null 2>&1; then \
+		echo "== bicep build (syntax + type check) =="; \
+		for f in infra/azure/main.bicep infra/azure/modules/*.bicep; do \
+			echo "-- $$f"; \
+			az bicep build --file "$$f" --stdout > /dev/null || exit 1; \
+		done; \
+	else \
+		echo "az CLI not installed locally, skipping Bicep validation (CI validates on every push): https://learn.microsoft.com/cli/azure/install-azure-cli"; \
+	fi
+	@echo "== deploy-azure.yml is valid YAML =="
+	@python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-azure.yml'))" 2>/dev/null || \
+		{ echo "deploy-azure.yml failed to parse as YAML"; exit 1; }
+
+deploy-check: lint-infra
+	@echo "== go build/vet the billing + persistence code path =="
+	@go build ./governance/... ./tools/httpserver/...
+	@go vet ./governance/... ./tools/httpserver/...
+	@echo "== go test the billing + persistence code path =="
+	@go test ./governance/... ./tools/httpserver/... -run "Billing|Webhook|Checkout|Portal|Stripe" -count=1
+	@if command -v az >/dev/null 2>&1 && az account show >/dev/null 2>&1; then \
+		echo "== az deployment group what-if (dry run against $${RESOURCE_GROUP:-joltrin-prod-rg}) =="; \
+		az deployment group what-if \
+			-g "$${RESOURCE_GROUP:-joltrin-prod-rg}" \
+			-f infra/azure/main.bicep \
+			-p infra/azure/main.parameters.json \
+			-p alertEmail=deploy-check@example.com stripeSecretKey=sk_dry_run stripeWebhookSecret=whsec_dry_run || true; \
+	else \
+		echo "az CLI not installed or not logged in, skipping what-if (CI runs the real deployment on merge to master)."; \
+	fi
+	@echo "deploy-check passed."

--- a/governance/billing.go
+++ b/governance/billing.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -200,14 +201,20 @@ type DefaultBillingService struct {
 	cfg             StripeConfig
 	httpClient      *http.Client
 	gate            *FeatureGate
-	subscriptions   map[string]*Subscription      // tenantID -> Subscription
-	customerMap     map[string]string             // customerID -> tenantID
-	processedEvents map[string]time.Time          // eventID -> processedAt (idempotency)
-	inquiries       map[string]*EnterpriseInquiry // inquiryID -> inquiry
+	store           BillingStore                  // durable backing store; nil means in-memory only
+	subscriptions   map[string]*Subscription      // tenantID -> Subscription (read cache)
+	customerMap     map[string]string             // customerID -> tenantID (read cache)
+	processedEvents map[string]time.Time          // eventID -> processedAt (idempotency, read cache)
+	inquiries       map[string]*EnterpriseInquiry // inquiryID -> inquiry (read cache)
 }
 
-// NewDefaultBillingService constructs a new BillingService.
-func NewDefaultBillingService(cfg StripeConfig, gate *FeatureGate) *DefaultBillingService {
+// NewDefaultBillingService constructs a new BillingService. Passing a
+// BillingStore makes subscriptions, webhook idempotency keys, and enterprise
+// inquiries durable across restarts; every write goes through to it, and its
+// contents hydrate the in-memory read cache at construction time. Omitting
+// it (as existing tests and Simulate-only demos do) keeps the previous
+// in-memory-only behavior.
+func NewDefaultBillingService(cfg StripeConfig, gate *FeatureGate, store ...BillingStore) *DefaultBillingService {
 	if cfg.ProPriceID == "" {
 		cfg.ProPriceID = "price_joltrin_pro_monthly"
 	}
@@ -218,7 +225,7 @@ func NewDefaultBillingService(cfg StripeConfig, gate *FeatureGate) *DefaultBilli
 		cfg.Simulate = true
 	}
 
-	return &DefaultBillingService{
+	s := &DefaultBillingService{
 		cfg:             cfg,
 		httpClient:      &http.Client{Timeout: 15 * time.Second},
 		gate:            gate,
@@ -227,12 +234,95 @@ func NewDefaultBillingService(cfg StripeConfig, gate *FeatureGate) *DefaultBilli
 		processedEvents: make(map[string]time.Time),
 		inquiries:       make(map[string]*EnterpriseInquiry),
 	}
+	if len(store) > 0 {
+		s.store = store[0]
+	}
+	if s.store != nil {
+		s.hydrateFromStore(context.Background())
+	}
+	return s
+}
+
+// hydrateFromStore loads durable billing state into the in-memory read cache.
+// Called once at construction; failures are logged to stderr rather than
+// treated as fatal, since a fresh/empty store is a normal first-run state.
+func (s *DefaultBillingService) hydrateFromStore(ctx context.Context) {
+	if subs, err := s.store.ListSubscriptions(ctx); err == nil {
+		for _, sub := range subs {
+			s.subscriptions[sub.TenantID] = sub
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "governance/billing: hydrate subscriptions: %v\n", err)
+	}
+	if cm, err := s.store.ListCustomerTenants(ctx); err == nil {
+		s.customerMap = cm
+	} else {
+		fmt.Fprintf(os.Stderr, "governance/billing: hydrate customer map: %v\n", err)
+	}
+	if pe, err := s.store.ListProcessedEvents(ctx); err == nil {
+		s.processedEvents = pe
+	} else {
+		fmt.Fprintf(os.Stderr, "governance/billing: hydrate processed events: %v\n", err)
+	}
+	if inqs, err := s.store.ListInquiries(ctx); err == nil {
+		for _, inq := range inqs {
+			s.inquiries[inq.ID] = inq
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "governance/billing: hydrate inquiries: %v\n", err)
+	}
 }
 
 func (s *DefaultBillingService) Config() StripeConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.cfg
+}
+
+// stripeRequest performs a form-encoded POST against the Stripe API with
+// bounded retry-with-backoff on 429 (rate limited) and 5xx (Stripe outage)
+// responses; 4xx-other-than-429 responses are returned immediately since a
+// retry won't change a malformed or rejected request. This is the graceful
+// degradation layer for a commercial billing surface: a single Stripe blip
+// shouldn't fail a customer's checkout outright.
+func (s *DefaultBillingService) stripeRequest(ctx context.Context, method, url, body string) (*http.Response, []byte, error) {
+	const maxAttempts = 3
+	backoff := 500 * time.Millisecond
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+		if err != nil {
+			return nil, nil, fmt.Errorf("governance/billing: failed to create request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+s.cfg.SecretKey)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("governance/billing: stripe api error: %w", err)
+		} else {
+			bodyBytes, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				return nil, nil, fmt.Errorf("governance/billing: failed reading stripe response: %w", readErr)
+			}
+			if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode < 500 {
+				return resp, bodyBytes, nil
+			}
+			lastErr = fmt.Errorf("governance/billing: stripe api returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		}
+
+		if attempt < maxAttempts {
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+	}
+	return nil, nil, lastErr
 }
 
 // CreateCheckoutSession generates a Stripe Checkout session or a deterministic simulated session.
@@ -298,22 +388,9 @@ func (s *DefaultBillingService) CreateCheckoutSession(ctx context.Context, tenan
 	data.Set("success_url", successURL)
 	data.Set("cancel_url", cancelURL)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.stripe.com/v1/checkout/sessions", strings.NewReader(data.Encode()))
+	resp, bodyBytes, err := s.stripeRequest(ctx, http.MethodPost, "https://api.stripe.com/v1/checkout/sessions", data.Encode())
 	if err != nil {
-		return nil, fmt.Errorf("governance/billing: failed to create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+s.cfg.SecretKey)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("governance/billing: stripe api error: %w", err)
-	}
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("governance/billing: failed reading stripe response: %w", err)
+		return nil, err
 	}
 
 	if resp.StatusCode >= 400 {
@@ -355,20 +432,10 @@ func (s *DefaultBillingService) CreatePortalSession(ctx context.Context, custome
 		data.Set("return_url", returnURL)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.stripe.com/v1/billing_portal/sessions", strings.NewReader(data.Encode()))
+	resp, body, err := s.stripeRequest(ctx, http.MethodPost, "https://api.stripe.com/v1/billing_portal/sessions", data.Encode())
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Authorization", "Bearer "+s.cfg.SecretKey)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("governance/billing: stripe portal error: %s", string(body))
 	}
@@ -404,7 +471,13 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 	if _, exists := s.processedEvents[ev.ID]; exists {
 		return nil, fmt.Errorf("%w: %s", ErrDuplicateWebhookEvent, ev.ID)
 	}
-	s.processedEvents[ev.ID] = time.Now().UTC()
+	processedAt := time.Now().UTC()
+	s.processedEvents[ev.ID] = processedAt
+	if s.store != nil {
+		if err := s.store.MarkProcessedEvent(ctx, ev.ID, processedAt); err != nil {
+			return nil, fmt.Errorf("governance/billing: persist processed event: %w", err)
+		}
+	}
 
 	// Clean up old events cache (> 24 hours)
 	if len(s.processedEvents) > 5000 {
@@ -423,6 +496,7 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 	}
 
 	now := time.Now().UTC()
+	var affectedTenant, affectedCustomer string
 
 	switch ev.Type {
 	case "checkout.session.completed":
@@ -464,6 +538,7 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 		if customerID != "" {
 			s.customerMap[customerID] = tenantID
 		}
+		affectedTenant, affectedCustomer = tenantID, customerID
 
 		// Dynamically upgrade server FeatureGate
 		if s.gate != nil {
@@ -516,6 +591,7 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 		existing.PlanTier = targetTier
 		existing.Status = status
 		existing.UpdatedAt = now
+		affectedTenant, affectedCustomer = tenantID, customerID
 
 		if s.gate != nil {
 			if status == SubStatusActive || status == SubStatusTrialing {
@@ -535,6 +611,7 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 		if sub, ok := s.subscriptions[tenantID]; ok {
 			sub.Status = SubStatusCanceled
 			sub.UpdatedAt = now
+			affectedTenant = tenantID
 		}
 
 		// Revert to open-source core tier
@@ -549,6 +626,7 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 			if sub, ok := s.subscriptions[tenantID]; ok {
 				sub.Status = SubStatusActive
 				sub.UpdatedAt = now
+				affectedTenant = tenantID
 				if s.gate != nil {
 					s.gate.SetTier(sub.PlanTier)
 				}
@@ -562,6 +640,20 @@ func (s *DefaultBillingService) HandleWebhook(ctx context.Context, payload []byt
 			if sub, ok := s.subscriptions[tenantID]; ok {
 				sub.Status = SubStatusPastDue
 				sub.UpdatedAt = now
+				affectedTenant = tenantID
+			}
+		}
+	}
+
+	if s.store != nil && affectedTenant != "" {
+		if sub, ok := s.subscriptions[affectedTenant]; ok {
+			if err := s.store.PutSubscription(ctx, sub); err != nil {
+				return nil, fmt.Errorf("governance/billing: persist subscription: %w", err)
+			}
+		}
+		if affectedCustomer != "" {
+			if err := s.store.PutCustomerTenant(ctx, affectedCustomer, affectedTenant); err != nil {
+				return nil, fmt.Errorf("governance/billing: persist customer mapping: %w", err)
 			}
 		}
 	}
@@ -608,6 +700,16 @@ func (s *DefaultBillingService) SetSubscription(ctx context.Context, sub *Subscr
 	if sub.CustomerID != "" {
 		s.customerMap[sub.CustomerID] = sub.TenantID
 	}
+	if s.store != nil {
+		if err := s.store.PutSubscription(ctx, sub); err != nil {
+			return fmt.Errorf("governance/billing: persist subscription: %w", err)
+		}
+		if sub.CustomerID != "" {
+			if err := s.store.PutCustomerTenant(ctx, sub.CustomerID, sub.TenantID); err != nil {
+				return fmt.Errorf("governance/billing: persist customer mapping: %w", err)
+			}
+		}
+	}
 
 	if s.gate != nil && sub.Status == SubStatusActive {
 		s.gate.SetTier(sub.PlanTier)
@@ -635,6 +737,11 @@ func (s *DefaultBillingService) SubmitEnterpriseInquiry(ctx context.Context, inq
 	inq.CreatedAt = time.Now().UTC()
 
 	s.inquiries[inq.ID] = inq
+	if s.store != nil {
+		if err := s.store.PutInquiry(ctx, inq); err != nil {
+			return nil, fmt.Errorf("governance/billing: persist inquiry: %w", err)
+		}
+	}
 	return inq, nil
 }
 

--- a/governance/billing_store.go
+++ b/governance/billing_store.go
@@ -1,0 +1,315 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sop "github.com/sharedcode/joltrin"
+	"github.com/sharedcode/joltrin/database"
+)
+
+// BillingStore persists commercial billing state - subscriptions, the
+// customer-to-tenant mapping, webhook idempotency keys, and enterprise
+// inquiries - so it survives a process restart or redeploy. DefaultBillingService
+// keeps its existing in-memory maps as a read cache and writes through to a
+// BillingStore when one is configured; a nil store preserves the old
+// in-memory-only behavior (used by unit tests and Simulate-only demos).
+type BillingStore interface {
+	GetSubscription(ctx context.Context, tenantID string) (*Subscription, bool, error)
+	PutSubscription(ctx context.Context, sub *Subscription) error
+	ListSubscriptions(ctx context.Context) ([]*Subscription, error)
+
+	ResolveTenantByCustomer(ctx context.Context, customerID string) (string, bool, error)
+	PutCustomerTenant(ctx context.Context, customerID, tenantID string) error
+	ListCustomerTenants(ctx context.Context) (map[string]string, error)
+
+	HasProcessedEvent(ctx context.Context, eventID string) (bool, error)
+	MarkProcessedEvent(ctx context.Context, eventID string, at time.Time) error
+	ListProcessedEvents(ctx context.Context) (map[string]time.Time, error)
+
+	PutInquiry(ctx context.Context, inq *EnterpriseInquiry) error
+	ListInquiries(ctx context.Context) ([]*EnterpriseInquiry, error)
+}
+
+const (
+	billingStoreSubscriptions   = "governance_subscriptions"
+	billingStoreCustomerTenants = "governance_customer_tenants"
+	billingStoreProcessedEvents = "governance_processed_events"
+	billingStoreInquiries       = "governance_inquiries"
+)
+
+// JoltrinBillingStore is a BillingStore backed by joltrin's own embedded
+// B-Tree engine. Using the engine this repo ships avoids standing up a
+// separate database (Redis, Postgres, etc.) just to hold a few KB of
+// subscription and idempotency records.
+type JoltrinBillingStore struct {
+	dbOpts sop.DatabaseOptions
+}
+
+// NewJoltrinBillingStore returns a BillingStore rooted at dataPath, in
+// Standalone mode (single writer). This intentionally does not enable
+// Redis-backed distributed locking: the deployment this backs runs the
+// Container App pinned to a single replica, so a single-process embedded
+// store is sufficient and keeps infrastructure cost at zero for this piece.
+func NewJoltrinBillingStore(dataPath string) *JoltrinBillingStore {
+	return &JoltrinBillingStore{
+		dbOpts: sop.DatabaseOptions{
+			Type:          sop.Standalone,
+			StoresFolders: []string{dataPath},
+		},
+	}
+}
+
+func (s *JoltrinBillingStore) GetSubscription(ctx context.Context, tenantID string) (*Subscription, bool, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return nil, false, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, Subscription](ctx, s.dbOpts, billingStoreSubscriptions, trans, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("governance/billing: open subscriptions store: %w", err)
+	}
+
+	found, err := store.Find(ctx, tenantID, true)
+	if err != nil || !found {
+		return nil, false, err
+	}
+	sub, err := store.GetCurrentValue(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	return &sub, true, nil
+}
+
+func (s *JoltrinBillingStore) PutSubscription(ctx context.Context, sub *Subscription) error {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForWriting)
+	if err != nil {
+		return fmt.Errorf("governance/billing: begin write transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, Subscription](ctx, s.dbOpts, billingStoreSubscriptions, trans, nil)
+	if err != nil {
+		return fmt.Errorf("governance/billing: open subscriptions store: %w", err)
+	}
+	if _, err := store.Upsert(ctx, sub.TenantID, *sub); err != nil {
+		return fmt.Errorf("governance/billing: upsert subscription: %w", err)
+	}
+	return trans.Commit(ctx)
+}
+
+func (s *JoltrinBillingStore) ListSubscriptions(ctx context.Context) ([]*Subscription, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, Subscription](ctx, s.dbOpts, billingStoreSubscriptions, trans, nil)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: open subscriptions store: %w", err)
+	}
+
+	var out []*Subscription
+	ok, err := store.First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for ok {
+		v, err := store.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+		item := v
+		out = append(out, &item)
+		if ok, err = store.Next(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *JoltrinBillingStore) ResolveTenantByCustomer(ctx context.Context, customerID string) (string, bool, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return "", false, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, string](ctx, s.dbOpts, billingStoreCustomerTenants, trans, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("governance/billing: open customer-tenant store: %w", err)
+	}
+
+	found, err := store.Find(ctx, customerID, true)
+	if err != nil || !found {
+		return "", false, err
+	}
+	tenantID, err := store.GetCurrentValue(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	return tenantID, true, nil
+}
+
+func (s *JoltrinBillingStore) PutCustomerTenant(ctx context.Context, customerID, tenantID string) error {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForWriting)
+	if err != nil {
+		return fmt.Errorf("governance/billing: begin write transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, string](ctx, s.dbOpts, billingStoreCustomerTenants, trans, nil)
+	if err != nil {
+		return fmt.Errorf("governance/billing: open customer-tenant store: %w", err)
+	}
+	if _, err := store.Upsert(ctx, customerID, tenantID); err != nil {
+		return fmt.Errorf("governance/billing: upsert customer-tenant mapping: %w", err)
+	}
+	return trans.Commit(ctx)
+}
+
+func (s *JoltrinBillingStore) ListCustomerTenants(ctx context.Context) (map[string]string, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, string](ctx, s.dbOpts, billingStoreCustomerTenants, trans, nil)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: open customer-tenant store: %w", err)
+	}
+
+	out := make(map[string]string)
+	ok, err := store.First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for ok {
+		k := store.GetCurrentKey()
+		v, err := store.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out[k.Key] = v
+		if ok, err = store.Next(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *JoltrinBillingStore) HasProcessedEvent(ctx context.Context, eventID string) (bool, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return false, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, time.Time](ctx, s.dbOpts, billingStoreProcessedEvents, trans, nil)
+	if err != nil {
+		return false, fmt.Errorf("governance/billing: open processed-events store: %w", err)
+	}
+	found, err := store.Find(ctx, eventID, true)
+	return found, err
+}
+
+func (s *JoltrinBillingStore) MarkProcessedEvent(ctx context.Context, eventID string, at time.Time) error {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForWriting)
+	if err != nil {
+		return fmt.Errorf("governance/billing: begin write transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, time.Time](ctx, s.dbOpts, billingStoreProcessedEvents, trans, nil)
+	if err != nil {
+		return fmt.Errorf("governance/billing: open processed-events store: %w", err)
+	}
+	if _, err := store.Upsert(ctx, eventID, at); err != nil {
+		return fmt.Errorf("governance/billing: upsert processed event: %w", err)
+	}
+	return trans.Commit(ctx)
+}
+
+func (s *JoltrinBillingStore) ListProcessedEvents(ctx context.Context) (map[string]time.Time, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, time.Time](ctx, s.dbOpts, billingStoreProcessedEvents, trans, nil)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: open processed-events store: %w", err)
+	}
+
+	out := make(map[string]time.Time)
+	ok, err := store.First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for ok {
+		k := store.GetCurrentKey()
+		v, err := store.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out[k.Key] = v
+		if ok, err = store.Next(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *JoltrinBillingStore) PutInquiry(ctx context.Context, inq *EnterpriseInquiry) error {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForWriting)
+	if err != nil {
+		return fmt.Errorf("governance/billing: begin write transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, EnterpriseInquiry](ctx, s.dbOpts, billingStoreInquiries, trans, nil)
+	if err != nil {
+		return fmt.Errorf("governance/billing: open inquiries store: %w", err)
+	}
+	if _, err := store.Upsert(ctx, inq.ID, *inq); err != nil {
+		return fmt.Errorf("governance/billing: upsert inquiry: %w", err)
+	}
+	return trans.Commit(ctx)
+}
+
+func (s *JoltrinBillingStore) ListInquiries(ctx context.Context) ([]*EnterpriseInquiry, error) {
+	trans, err := database.BeginTransaction(ctx, s.dbOpts, sop.ForReading)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: begin read transaction: %w", err)
+	}
+	defer trans.Rollback(ctx)
+
+	store, err := database.NewBtree[string, EnterpriseInquiry](ctx, s.dbOpts, billingStoreInquiries, trans, nil)
+	if err != nil {
+		return nil, fmt.Errorf("governance/billing: open inquiries store: %w", err)
+	}
+
+	var out []*EnterpriseInquiry
+	ok, err := store.First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for ok {
+		v, err := store.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+		item := v
+		out = append(out, &item)
+		if ok, err = store.Next(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/governance/billing_store_test.go
+++ b/governance/billing_store_test.go
@@ -1,0 +1,177 @@
+package governance
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStripeRequest_RetriesOn500ThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"stripe unavailable"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"cs_ok"}`))
+	}))
+	defer srv.Close()
+
+	svc := NewDefaultBillingService(StripeConfig{SecretKey: "sk_test"}, nil)
+
+	resp, body, err := svc.stripeRequest(context.Background(), http.MethodPost, srv.URL, "")
+	if err != nil {
+		t.Fatalf("expected eventual success after retries, got err: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != `{"id":"cs_ok"}` {
+		t.Fatalf("unexpected response: status=%d body=%s", resp.StatusCode, body)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts (2 failures + 1 success), got %d", got)
+	}
+}
+
+func TestStripeRequest_NoRetryOn400(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"invalid request"}`))
+	}))
+	defer srv.Close()
+
+	svc := NewDefaultBillingService(StripeConfig{SecretKey: "sk_test"}, nil)
+	resp, _, err := svc.stripeRequest(context.Background(), http.MethodPost, srv.URL, "")
+	if err != nil {
+		t.Fatalf("expected the 400 to be returned rather than treated as a transport error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 passthrough, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retry on 4xx), got %d", got)
+	}
+}
+
+func TestJoltrinBillingStore_SubscriptionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := NewJoltrinBillingStore(t.TempDir())
+
+	if _, found, err := store.GetSubscription(ctx, "tenant-a"); err != nil {
+		t.Fatalf("GetSubscription on empty store: %v", err)
+	} else if found {
+		t.Fatal("expected no subscription on empty store")
+	}
+
+	sub := &Subscription{
+		ID:         "sub_123",
+		TenantID:   "tenant-a",
+		CustomerID: "cus_123",
+		PlanTier:   TierPro,
+		Status:     SubStatusActive,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	if err := store.PutSubscription(ctx, sub); err != nil {
+		t.Fatalf("PutSubscription: %v", err)
+	}
+
+	got, found, err := store.GetSubscription(ctx, "tenant-a")
+	if err != nil || !found {
+		t.Fatalf("GetSubscription after put: found=%v err=%v", found, err)
+	}
+	if got.CustomerID != "cus_123" || got.PlanTier != TierPro {
+		t.Fatalf("unexpected subscription round-trip: %+v", got)
+	}
+
+	subs, err := store.ListSubscriptions(ctx)
+	if err != nil || len(subs) != 1 {
+		t.Fatalf("ListSubscriptions: got %d, err %v", len(subs), err)
+	}
+}
+
+func TestJoltrinBillingStore_ProcessedEventIdempotency(t *testing.T) {
+	ctx := context.Background()
+	store := NewJoltrinBillingStore(t.TempDir())
+
+	if seen, err := store.HasProcessedEvent(ctx, "evt_1"); err != nil || seen {
+		t.Fatalf("expected evt_1 unseen, got seen=%v err=%v", seen, err)
+	}
+	if err := store.MarkProcessedEvent(ctx, "evt_1", time.Now().UTC()); err != nil {
+		t.Fatalf("MarkProcessedEvent: %v", err)
+	}
+	if seen, err := store.HasProcessedEvent(ctx, "evt_1"); err != nil || !seen {
+		t.Fatalf("expected evt_1 seen after marking, got seen=%v err=%v", seen, err)
+	}
+}
+
+func TestJoltrinBillingStore_CustomerTenantMapping(t *testing.T) {
+	ctx := context.Background()
+	store := NewJoltrinBillingStore(t.TempDir())
+
+	if err := store.PutCustomerTenant(ctx, "cus_1", "tenant-a"); err != nil {
+		t.Fatalf("PutCustomerTenant: %v", err)
+	}
+	tenantID, found, err := store.ResolveTenantByCustomer(ctx, "cus_1")
+	if err != nil || !found || tenantID != "tenant-a" {
+		t.Fatalf("ResolveTenantByCustomer: tenantID=%q found=%v err=%v", tenantID, found, err)
+	}
+}
+
+func TestJoltrinBillingStore_InquiryRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := NewJoltrinBillingStore(t.TempDir())
+
+	inq := &EnterpriseInquiry{ID: "inq_1", Name: "Jane Doe", Email: "jane@example.com", Status: "new"}
+	if err := store.PutInquiry(ctx, inq); err != nil {
+		t.Fatalf("PutInquiry: %v", err)
+	}
+	list, err := store.ListInquiries(ctx)
+	if err != nil || len(list) != 1 || list[0].Email != "jane@example.com" {
+		t.Fatalf("ListInquiries: got %+v, err %v", list, err)
+	}
+}
+
+// TestDefaultBillingService_SurvivesRestart is the scenario this store exists
+// for: a Container App restart should not wipe a paying customer's
+// subscription. It simulates a restart by constructing two BillingService
+// instances against the same on-disk store.
+func TestDefaultBillingService_SurvivesRestart(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+
+	store1 := NewJoltrinBillingStore(dataDir)
+	gate1 := NewFeatureGate(TierCore)
+	svc1 := NewDefaultBillingService(StripeConfig{Simulate: true}, gate1, store1)
+
+	sub := &Subscription{
+		ID:         "sub_restart",
+		TenantID:   "tenant-restart",
+		CustomerID: "cus_restart",
+		PlanTier:   TierEnterprise,
+		Status:     SubStatusActive,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	if err := svc1.SetSubscription(ctx, sub); err != nil {
+		t.Fatalf("SetSubscription: %v", err)
+	}
+
+	// Simulate a restart: a brand new process, new service, same data directory.
+	store2 := NewJoltrinBillingStore(dataDir)
+	gate2 := NewFeatureGate(TierCore)
+	svc2 := NewDefaultBillingService(StripeConfig{Simulate: true}, gate2, store2)
+
+	got, err := svc2.GetSubscription(ctx, "tenant-restart")
+	if err != nil {
+		t.Fatalf("GetSubscription after restart: %v", err)
+	}
+	if got.PlanTier != TierEnterprise || got.Status != SubStatusActive {
+		t.Fatalf("subscription did not survive restart, got %+v", got)
+	}
+}

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -1,0 +1,65 @@
+# Azure Container Apps deployment
+
+Deploys `tools/httpserver` (the Data Manager UI + commercial Stripe billing
+surface) to Azure Container Apps. Provisioned by `.github/workflows/deploy-azure.yml`
+on push to `master`; this doc covers what it provisions and how to run it by hand.
+
+## What this provisions
+
+- **Resource Group** (created by the workflow before the Bicep deployment)
+- **Azure Container Registry** (Basic SKU, admin user disabled - pulls only via managed identity)
+- **User-assigned managed identity** with `AcrPull` on the registry and `Key Vault Secrets User` on the vault
+- **Key Vault** (RBAC-authorized) holding the Stripe secret key, webhook secret, and publishable key
+- **Log Analytics workspace** (30-day retention, caps ingestion cost)
+- **Container Apps environment** wired to that workspace
+- **Container App**, pinned to `minReplicas = maxReplicas = 1` (see the comment in `modules/container-app.bicep` for why), 0.5 vCPU / 1Gi, liveness/readiness/startup probes on `/api/health`
+- **Cost budget** with alerts at 50/75/90/100% of a monthly USD threshold
+- **Azure Monitor metric alerts** (CPU%, memory%, restart-loop) on the Container App, wired to an email action group
+
+## Why pinned to 1 replica, and no Redis
+
+joltrin's embedded B-Tree engine has no documented guarantee of safe
+concurrent multi-process writes to the same data path. It does ship a
+Redis-backed distributed-locking `L2Cache` (`adapters/redis`) that would make
+horizontal scaling safe, but this deployment is optimized for lowest cost, so
+it stays single-replica instead of adding an Azure Cache for Redis instance.
+Revisit `container-app.bicep`'s `minReplicas`/`maxReplicas` if that tradeoff
+changes.
+
+## Why Azure Monitor alerts, not Managed Prometheus/Grafana
+
+Both are real, billed Azure resources (ingestion + workspace cost) that a
+single-replica, personal-scale deployment doesn't need. Native platform
+metric alerts on the Container App resource cost a few cents/month per rule
+and cover the same guardrails (CPU, memory, restart loops).
+
+## Deploying by hand
+
+```bash
+az group create -n joltrin-prod-rg -l eastus
+
+az deployment group create \
+  -g joltrin-prod-rg \
+  -f infra/azure/main.bicep \
+  -p infra/azure/main.parameters.json \
+  -p containerImage=<acr-login-server>/joltrin:<tag> \
+  -p alertEmail=<your-email> \
+  -p stripeSecretKey=<from a secret manager, never a shell history file> \
+  -p stripeWebhookSecret=<same>
+```
+
+The first deploy provisions the ACR before an image exists in it; build and
+push the image, then re-run `az deployment group create` with the resulting
+`containerImage` value (this is exactly what `deploy-azure.yml` automates).
+
+## Before the first real deploy
+
+Verify the Azure Monitor metric names used in `modules/monitor-alerts.bicep`
+against the live resource - Container Apps metric names have changed across
+API versions before:
+
+```bash
+az monitor metrics list-definitions --resource <container-app-resource-id>
+```
+
+If they've drifted, update the `metricName` values in that file.

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -1,0 +1,141 @@
+// Azure Container Apps deployment for tools/httpserver (the joltrin commercial
+// billing/Data Manager surface). Deploy at resource-group scope:
+//
+//   az group create -n <rg> -l <location>
+//   az deployment group create -g <rg> -f infra/azure/main.bicep \
+//     -p infra/azure/main.parameters.json
+//
+// Design intent (see PR description for the full tradeoff writeup):
+//   - Single Container App revision, pinned to minReplicas=maxReplicas=1.
+//     joltrin's embedded B-Tree engine has no documented multi-process
+//     write-safety guarantee, and the deployment target is least-cost, so
+//     this deploy does not add Azure Cache for Redis to unlock horizontal
+//     scaling. CPU/memory/concurrency limits are enforced as guardrails
+//     against runaway cost and restart loops, not as autoscaling fan-out.
+//   - Azure Monitor native metric alerts (not Managed Prometheus/Grafana)
+//     watch CPU%, memory%, and replica restarts, because a managed
+//     Prometheus/Grafana stack adds meaningful monthly cost that a
+//     single-replica personal-scale deployment doesn't need.
+//   - Billing secrets (Stripe keys) live in Key Vault and are injected via
+//     secret references, never as plaintext env vars or in source control.
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Short environment/app name used as a resource-name prefix.')
+param appName string = 'joltrin'
+
+@description('Container image reference, e.g. <acr-login-server>/joltrin:<tag>. Defaults to a public placeholder so the infra can be deployed before the ACR has a real image in it (first-run bootstrap); CI updates the running revision separately via `az containerapp update` once the real image is pushed.')
+param containerImage string = 'mcr.microsoft.com/k8se/quickstart:latest'
+
+@description('Email address that receives budget and health alerts.')
+param alertEmail string
+
+@description('Monthly cost budget in USD before the 100% alert fires.')
+param monthlyBudgetUsd int = 25
+
+@secure()
+@description('Stripe secret key. Stored in Key Vault, never in source control or plain env vars.')
+param stripeSecretKey string
+
+@secure()
+@description('Stripe webhook signing secret.')
+param stripeWebhookSecret string
+
+@description('Stripe publishable key (not secret, but kept alongside the others for consistency).')
+param stripePublishableKey string = ''
+
+var resourceToken = uniqueString(resourceGroup().id, appName)
+var logAnalyticsName = '${appName}-logs-${resourceToken}'
+var acrName = replace('${appName}acr${resourceToken}', '-', '')
+var kvName = take('${appName}-kv-${resourceToken}', 24)
+var envName = '${appName}-env-${resourceToken}'
+var containerAppName = '${appName}-app'
+var uamiName = '${appName}-acr-pull-identity'
+var actionGroupName = '${appName}-alerts'
+
+module logAnalytics 'modules/log-analytics.bicep' = {
+  name: 'logAnalytics'
+  params: {
+    name: logAnalyticsName
+    location: location
+    retentionInDays: 30 // caps ingestion cost; do not raise without reviewing Log Analytics billing
+  }
+}
+
+module acr 'modules/container-registry.bicep' = {
+  name: 'containerRegistry'
+  params: {
+    name: acrName
+    location: location
+  }
+}
+
+module identity 'modules/identity.bicep' = {
+  name: 'acrPullIdentity'
+  params: {
+    name: uamiName
+    location: location
+    acrName: acr.outputs.name
+  }
+}
+
+module keyVault 'modules/key-vault.bicep' = {
+  name: 'keyVault'
+  params: {
+    name: kvName
+    location: location
+    principalIdForAccess: identity.outputs.principalId
+    stripeSecretKey: stripeSecretKey
+    stripeWebhookSecret: stripeWebhookSecret
+    stripePublishableKey: stripePublishableKey
+  }
+}
+
+module containerAppsEnv 'modules/container-apps-environment.bicep' = {
+  name: 'containerAppsEnvironment'
+  params: {
+    name: envName
+    location: location
+    logAnalyticsCustomerId: logAnalytics.outputs.customerId
+    logAnalyticsSharedKey: logAnalytics.outputs.primarySharedKey
+  }
+}
+
+module containerApp 'modules/container-app.bicep' = {
+  name: 'containerApp'
+  params: {
+    name: containerAppName
+    location: location
+    environmentId: containerAppsEnv.outputs.id
+    containerImage: containerImage
+    acrLoginServer: acr.outputs.loginServer
+    userAssignedIdentityId: identity.outputs.id
+    userAssignedIdentityClientId: identity.outputs.clientId
+    keyVaultUri: keyVault.outputs.uri
+  }
+}
+
+module budget 'modules/budget.bicep' = {
+  name: 'costBudget'
+  params: {
+    appName: appName
+    alertEmail: alertEmail
+    monthlyBudgetUsd: monthlyBudgetUsd
+  }
+}
+
+module alerts 'modules/monitor-alerts.bicep' = {
+  name: 'monitorAlerts'
+  params: {
+    appName: appName
+    location: location
+    actionGroupName: actionGroupName
+    alertEmail: alertEmail
+    containerAppId: containerApp.outputs.id
+  }
+}
+
+output containerAppFqdn string = containerApp.outputs.fqdn
+output acrLoginServer string = acr.outputs.loginServer
+output keyVaultUri string = keyVault.outputs.uri

--- a/infra/azure/main.parameters.json
+++ b/infra/azure/main.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appName": {
+      "value": "joltrin"
+    },
+    "alertEmail": {
+      "value": "REPLACE_WITH_REAL_ALERT_EMAIL"
+    },
+    "monthlyBudgetUsd": {
+      "value": 25
+    },
+    "stripeSecretKey": {
+      "value": "REPLACE_AT_DEPLOY_TIME"
+    },
+    "stripeWebhookSecret": {
+      "value": "REPLACE_AT_DEPLOY_TIME"
+    },
+    "stripePublishableKey": {
+      "value": ""
+    }
+  }
+}

--- a/infra/azure/modules/budget.bicep
+++ b/infra/azure/modules/budget.bicep
@@ -1,0 +1,69 @@
+@description('App name prefix, used to name the budget.')
+param appName string
+
+param alertEmail string
+
+@description('Monthly spend threshold in USD. The 100% alert is the "something is wrong, go look" signal for a deployment sized to run cheaply.')
+param monthlyBudgetUsd int = 25
+
+@description('Budget start date, first of the current month. utcNow() is only valid as a param default in Bicep, hence this indirection.')
+param budgetStartDate string = utcNow('yyyy-MM-01')
+
+resource costBudget 'Microsoft.Consumption/budgets@2023-11-01' = {
+  name: '${appName}-monthly-budget'
+  properties: {
+    category: 'Cost'
+    amount: monthlyBudgetUsd
+    timeGrain: 'Monthly'
+    timePeriod: {
+      startDate: budgetStartDate
+    }
+    notifications: {
+      alert50pct: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 50
+        contactEmails: [
+          alertEmail
+        ]
+        thresholdType: 'Actual'
+      }
+      alert75pct: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 75
+        contactEmails: [
+          alertEmail
+        ]
+        thresholdType: 'Actual'
+      }
+      alert90pct: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 90
+        contactEmails: [
+          alertEmail
+        ]
+        thresholdType: 'Actual'
+      }
+      alert100pct: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 100
+        contactEmails: [
+          alertEmail
+        ]
+        thresholdType: 'Actual'
+      }
+      forecast100pct: {
+        enabled: true
+        operator: 'GreaterThanOrEqualTo'
+        threshold: 100
+        contactEmails: [
+          alertEmail
+        ]
+        thresholdType: 'Forecasted'
+      }
+    }
+  }
+}

--- a/infra/azure/modules/container-app.bicep
+++ b/infra/azure/modules/container-app.bicep
@@ -1,0 +1,170 @@
+@description('Container App name.')
+param name string
+
+param location string
+
+param environmentId string
+
+@description('Full image reference: <acr-login-server>/joltrin:<tag>.')
+param containerImage string
+
+param acrLoginServer string
+
+param userAssignedIdentityId string
+param userAssignedIdentityClientId string
+param keyVaultUri string
+
+// Pinned to 1 replica: joltrin's embedded B-Tree engine has no documented
+// multi-process write-safety guarantee, and this deployment optimizes for
+// lowest cost over horizontal scale. CPU/memory/concurrency limits below
+// are guardrails against runaway cost and restart loops on the single
+// replica, not an autoscaling fan-out policy. Revisit if/when the engine's
+// Redis-backed distributed locking (adapters/redis) is wired in and this
+// value is deliberately raised.
+var minReplicas = 1
+var maxReplicas = 1
+
+resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
+  name: name
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${userAssignedIdentityId}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: environmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: acrLoginServer
+          identity: userAssignedIdentityId
+        }
+      ]
+      secrets: [
+        {
+          name: 'stripe-secret-key'
+          keyVaultUrl: '${keyVaultUri}secrets/stripe-secret-key'
+          identity: userAssignedIdentityId
+        }
+        {
+          name: 'stripe-webhook-secret'
+          keyVaultUrl: '${keyVaultUri}secrets/stripe-webhook-secret'
+          identity: userAssignedIdentityId
+        }
+        {
+          name: 'stripe-publishable-key'
+          keyVaultUrl: '${keyVaultUri}secrets/stripe-publishable-key'
+          identity: userAssignedIdentityId
+        }
+      ]
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+        allowInsecure: false
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'joltrin-httpserver'
+          image: containerImage
+          // Matches the Dockerfile runtime stage's own values: EXPOSE 8080,
+          // ENTRYPOINT sop-server, ENV datapath=/var/lib/sop.
+          command: [
+            'sop-server'
+          ]
+          args: [
+            '-database'
+            '/var/lib/sop'
+            '-port'
+            '8080'
+            '-open-browser=false'
+          ]
+          env: [
+            {
+              name: 'STRIPE_SECRET_KEY'
+              secretRef: 'stripe-secret-key'
+            }
+            {
+              name: 'STRIPE_WEBHOOK_SECRET'
+              secretRef: 'stripe-webhook-secret'
+            }
+            {
+              name: 'STRIPE_PUBLISHABLE_KEY'
+              secretRef: 'stripe-publishable-key'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: userAssignedIdentityClientId
+            }
+          ]
+          // 0.5 vCPU / 1.0 GiB: matches the requested cost-containment
+          // sizing. Combined GB-CPU pairing is one of ACA's valid
+          // combinations (0.5 vCPU pairs with 1Gi).
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/api/health'
+                port: 8080
+              }
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              failureThreshold: 3
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/api/health'
+                port: 8080
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 15
+              failureThreshold: 3
+            }
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/api/health'
+                port: 8080
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 10
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
+        rules: [
+          {
+            // Concurrency guardrail: with maxReplicas pinned to 1 this
+            // does not trigger scale-out, but it documents and caps the
+            // per-replica concurrent-request budget the ingress will
+            // queue against rather than letting requests pile up
+            // unbounded in front of a single instance.
+            name: 'http-concurrency-guardrail'
+            http: {
+              metadata: {
+                concurrentRequests: '50'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output id string = containerApp.id
+output fqdn string = containerApp.properties.configuration.ingress.fqdn

--- a/infra/azure/modules/container-apps-environment.bicep
+++ b/infra/azure/modules/container-apps-environment.bicep
@@ -1,0 +1,29 @@
+@description('Container Apps managed environment name.')
+param name string
+
+param location string
+
+param logAnalyticsCustomerId string
+
+@secure()
+param logAnalyticsSharedKey string
+
+resource env 'Microsoft.App/managedEnvironments@2023-11-02-preview' = {
+  name: name
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsCustomerId
+        sharedKey: logAnalyticsSharedKey
+      }
+    }
+    // zoneRedundant defaults to false: zone redundancy duplicates
+    // infrastructure across availability zones, which is a cost multiplier
+    // this single-replica, least-cost deployment doesn't need.
+  }
+}
+
+output id string = env.id
+output name string = env.name

--- a/infra/azure/modules/container-registry.bicep
+++ b/infra/azure/modules/container-registry.bicep
@@ -1,0 +1,23 @@
+@description('Azure Container Registry name (must be globally unique, alphanumeric only).')
+param name string
+
+param location string
+
+// Basic SKU: cheapest tier, sufficient for a single low-traffic app image.
+// Admin credentials are disabled - the Container App pulls exclusively via
+// its user-assigned managed identity (AcrPull role), never a shared key.
+resource acr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output name string = acr.name
+output id string = acr.id
+output loginServer string = acr.properties.loginServer

--- a/infra/azure/modules/identity.bicep
+++ b/infra/azure/modules/identity.bicep
@@ -1,0 +1,34 @@
+@description('User-assigned managed identity name.')
+param name string
+
+param location string
+
+@description('Name of the existing ACR to grant AcrPull on.')
+param acrName string
+
+var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d' // built-in AcrPull role
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: name
+  location: location
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: acrName
+}
+
+// Grants the Container App's identity pull-only access to the registry.
+// No admin user, no shared key - this is the only way the app can pull its image.
+resource acrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, identity.id, acrPullRoleId)
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: identity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output id string = identity.id
+output principalId string = identity.properties.principalId
+output clientId string = identity.properties.clientId

--- a/infra/azure/modules/key-vault.bicep
+++ b/infra/azure/modules/key-vault.bicep
@@ -1,0 +1,70 @@
+@description('Key Vault name.')
+param name string
+
+param location string
+
+@description('Principal ID (managed identity) to grant Key Vault Secrets User access to.')
+param principalIdForAccess string
+
+@secure()
+param stripeSecretKey string
+
+@secure()
+param stripeWebhookSecret string
+
+param stripePublishableKey string = ''
+
+var secretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6' // built-in Key Vault Secrets User role
+
+resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource secretsUserAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(vault.id, principalIdForAccess, secretsUserRoleId)
+  scope: vault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', secretsUserRoleId)
+    principalId: principalIdForAccess
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource secretStripeKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: vault
+  name: 'stripe-secret-key'
+  properties: {
+    value: stripeSecretKey
+  }
+}
+
+resource secretWebhookSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: vault
+  name: 'stripe-webhook-secret'
+  properties: {
+    value: stripeWebhookSecret
+  }
+}
+
+resource secretPublishableKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: vault
+  name: 'stripe-publishable-key'
+  properties: {
+    value: empty(stripePublishableKey) ? 'unset' : stripePublishableKey
+  }
+}
+
+output uri string = vault.properties.vaultUri
+output name string = vault.name

--- a/infra/azure/modules/log-analytics.bicep
+++ b/infra/azure/modules/log-analytics.bicep
@@ -1,0 +1,25 @@
+@description('Log Analytics workspace name.')
+param name string
+
+param location string
+
+@description('Data retention in days. Kept short deliberately: Log Analytics bills on ingestion and retained volume, and this workspace only needs enough history to debug a recent incident.')
+param retentionInDays int = 30
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: retentionInDays
+    features: {
+      disableLocalAuth: false
+    }
+  }
+}
+
+output customerId string = workspace.properties.customerId
+output primarySharedKey string = workspace.listKeys().primarySharedKey
+output id string = workspace.id

--- a/infra/azure/modules/monitor-alerts.bicep
+++ b/infra/azure/modules/monitor-alerts.bicep
@@ -1,0 +1,138 @@
+// Native Azure Monitor metric alerts on the Container App, watching the
+// guardrails this deployment relies on instead of real horizontal scaling
+// (see container-app.bicep for why replicas are pinned to 1). Deliberately
+// NOT Managed Prometheus/Managed Grafana: that stack has real monthly cost
+// (ingestion + workspace) that a single-replica, least-cost deployment
+// doesn't need. Metric alert rules cost a few cents/month each.
+//
+// IMPORTANT: the exact metric names for Microsoft.App/containerApps below
+// (cpuPercentage, memoryPercentage, restartCount) are the documented
+// standard-metric names as of this writing, but Azure has renamed Container
+// Apps metrics across API versions before. Before the first deploy, verify
+// them against the live resource:
+//   az monitor metrics list-definitions --resource <container-app-id>
+// and adjust the `metricName` values below if they've drifted.
+
+@description('App name prefix.')
+param appName string
+
+param location string
+
+param actionGroupName string
+
+param alertEmail string
+
+@description('Resource ID of the Container App to monitor.')
+param containerAppId string
+
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: actionGroupName
+  location: 'global'
+  properties: {
+    groupShortName: take(actionGroupName, 12)
+    enabled: true
+    emailReceivers: [
+      {
+        name: 'primary'
+        emailAddress: alertEmail
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+resource cpuAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: '${appName}-cpu-high'
+  location: 'global'
+  properties: {
+    severity: 2
+    enabled: true
+    scopes: [
+      containerAppId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'HighCpu'
+          metricName: 'CpuPercentage'
+          metricNamespace: 'Microsoft.App/containerApps'
+          operator: 'GreaterThanOrEqual'
+          threshold: 85
+          timeAggregation: 'Average'
+        }
+      ]
+    }
+    actions: [
+      {
+        actionGroupId: actionGroup.id
+      }
+    ]
+  }
+}
+
+resource memoryAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: '${appName}-memory-high'
+  location: 'global'
+  properties: {
+    severity: 2
+    enabled: true
+    scopes: [
+      containerAppId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'HighMemory'
+          metricName: 'MemoryPercentage'
+          metricNamespace: 'Microsoft.App/containerApps'
+          operator: 'GreaterThanOrEqual'
+          threshold: 85
+          timeAggregation: 'Average'
+        }
+      ]
+    }
+    actions: [
+      {
+        actionGroupId: actionGroup.id
+      }
+    ]
+  }
+}
+
+resource restartAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: '${appName}-restart-loop'
+  location: 'global'
+  properties: {
+    severity: 1
+    enabled: true
+    scopes: [
+      containerAppId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT15M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'RestartLoop'
+          metricName: 'RestartCount'
+          metricNamespace: 'Microsoft.App/containerApps'
+          operator: 'GreaterThanOrEqual'
+          threshold: 3
+          timeAggregation: 'Total'
+        }
+      ]
+    }
+    actions: [
+      {
+        actionGroupId: actionGroup.id
+      }
+    ]
+  }
+}

--- a/tools/httpserver/billing_handler.go
+++ b/tools/httpserver/billing_handler.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -14,7 +16,56 @@ import (
 var (
 	billingService     governance.BillingService
 	billingServiceOnce sync.Once
+
+	billingRateLimiter     *governance.TierRateLimiter
+	billingRateLimiterOnce sync.Once
 )
+
+// getBillingRateLimiter returns the shared tier-aware token-bucket limiter
+// (governance/gateway.go) guarding billing endpoints that either call out to
+// Stripe or aren't behind requireAuth/withAuth, so an automated flood can't
+// run up the Stripe API bill or spam webhook processing.
+func getBillingRateLimiter() *governance.TierRateLimiter {
+	billingRateLimiterOnce.Do(func() {
+		billingRateLimiter = governance.NewTierRateLimiter()
+	})
+	return billingRateLimiter
+}
+
+// clientIPKey extracts a best-effort client identifier for rate limiting.
+// Azure Container Apps' ingress sets X-Forwarded-For; RemoteAddr is the
+// fallback for direct/local connections.
+func clientIPKey(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if idx := strings.Index(fwd, ","); idx != -1 {
+			return strings.TrimSpace(fwd[:idx])
+		}
+		return strings.TrimSpace(fwd)
+	}
+	return r.RemoteAddr
+}
+
+// checkBillingRateLimit applies the tier-aware rate limit to a billing
+// request, keyed by client IP since these endpoints run pre-auth. Returns
+// false and writes a 429 response if the caller should be throttled; the
+// caller must return immediately when this returns false. Fails open on an
+// internal limiter error so a limiter bug cannot take down billing.
+func checkBillingRateLimit(w http.ResponseWriter, r *http.Request) bool {
+	identity := &governance.GatewayIdentity{
+		TenantID: clientIPKey(r),
+		Tier:     getServerFeatureGate().Tier(),
+	}
+	allowed, retryAfter, err := getBillingRateLimiter().Allow(r.Context(), identity)
+	if err != nil {
+		return true
+	}
+	if !allowed {
+		w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter.Seconds()))
+		writeJSONError(w, http.StatusTooManyRequests, "rate limit exceeded, retry later")
+		return false
+	}
+	return true
+}
 
 func getBillingService() governance.BillingService {
 	billingServiceOnce.Do(func() {
@@ -39,7 +90,19 @@ func getBillingService() governance.BillingService {
 			Simulate:          simulate,
 		}
 
-		billingService = governance.NewDefaultBillingService(cfg, gate)
+		// Subscriptions, webhook idempotency keys, and enterprise inquiries are
+		// persisted under a dedicated subfolder of the server's own data path
+		// (joltrin's own embedded store) so they survive a restart/redeploy
+		// instead of living only in process memory. Falls back to the same
+		// default as the -database flag if unset, rather than silently
+		// collapsing to a relative path in the current working directory.
+		dbPath := config.DatabasePath
+		if dbPath == "" {
+			dbPath = "/tmp/sop_data"
+		}
+		billingDataPath := filepath.Join(dbPath, "_billing")
+		store := governance.NewJoltrinBillingStore(billingDataPath)
+		billingService = governance.NewDefaultBillingService(cfg, gate, store)
 	})
 	return billingService
 }
@@ -77,6 +140,9 @@ func handleGetPlan(w http.ResponseWriter, r *http.Request) {
 func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !checkBillingRateLimit(w, r) {
 		return
 	}
 
@@ -123,6 +189,9 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 func handleCreatePortalSession(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !checkBillingRateLimit(w, r) {
 		return
 	}
 

--- a/tools/httpserver/billing_handler_test.go
+++ b/tools/httpserver/billing_handler_test.go
@@ -5,11 +5,32 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/sharedcode/joltrin/governance"
 )
+
+// TestMain isolates config.DatabasePath to a fresh temp directory before any
+// test runs. getBillingService() is a package-level sync.Once singleton
+// that persists billing state under config.DatabasePath; without this,
+// config.DatabasePath is "" during `go test` (main()'s flag.Parse never
+// runs), so the singleton would write real files under a relative
+// "_billing" path in the source tree, and that state would leak across
+// separate `go test` invocations (a duplicate-event false positive once
+// bit TestHandleSimulateCheckout locally).
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "joltrin-httpserver-test-*")
+	if err != nil {
+		panic(err)
+	}
+	config.DatabasePath = tmpDir
+
+	code := m.Run()
+	os.RemoveAll(tmpDir)
+	os.Exit(code)
+}
 
 func TestHandleGetPlan(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/billing/plan", nil)


### PR DESCRIPTION
## Summary

Deploys `tools/httpserver` (the Data Manager UI + commercial Stripe billing surface) to Azure Container Apps, built around one constraint: keep it least-cost, since this runs on a personal account.

- **Fixed a real bug found along the way**: subscriptions, the webhook idempotency map, the customer-tenant map, and enterprise inquiries all lived in plain in-process maps. A restart or redeploy silently wiped every paying customer's subscription. Backed `DefaultBillingService` with a new `governance.JoltrinBillingStore` — this repo's own embedded B-Tree engine — instead of adding Redis or another external dependency. See `TestDefaultBillingService_SurvivesRestart` for the regression test.
- Wired the existing, previously-unused `governance.TierRateLimiter` into the checkout/portal endpoints (keyed by client IP), and added bounded retry-with-backoff on Stripe 429/5xx responses.
- Added a Bicep stack under `infra/azure/` (Container Registry, Key Vault, Log Analytics, Container Apps environment/app, cost budget with 50/75/90/100% alerts, Azure Monitor metric alerts).
- Added `.github/workflows/deploy-azure.yml`, OIDC-authenticated (no stored client secret), gated by the same Trivy critical/high check as `security.yml`.
- Added `make deploy-check` / `make lint-infra`.

## Architecture decisions (made with the repo owner before implementing)

- **Container App pinned to `minReplicas = maxReplicas = 1`.** joltrin's embedded engine has no documented multi-process write-safety guarantee. It does ship a Redis-backed distributed lock (`adapters/redis`) that would make horizontal scaling safe, but that's a new billed Azure resource, so it's deliberately not wired in — least cost over replica fan-out.
- **IaC is Bicep, not Terraform** — a deliberate choice to build real ARM/Bicep experience rather than more Terraform.
- **Alerting is native Azure Monitor metric alerts**, not Managed Prometheus/Grafana, for the same cost reason (that stack has real monthly ingestion/workspace cost).
- **Idempotency/subscription persistence backs onto joltrin's own store**, not Redis or an external DB — no new paid resource, dogfoods the product.

## Release sequence

This merges to `master` first; `v5.5.0` gets tagged after this is in and CI is green, covering both the DevSecOps pipeline (already on `master` via #305) and this Azure Container Apps work together.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./governance/... ./tools/httpserver/...`
- [x] `go test ./governance/... ./tools/httpserver/... -count=1` (full suite, including new persistence/retry/rate-limit tests)
- [x] `make deploy-check` (Bicep syntax validated in CI where `az` is available; YAML validated locally)
- [ ] CI: ci.yml / go.yml / security.yml / codeql.yml / e2e.yml all green
- [ ] First `deploy-azure.yml` run on merge (provisions real Azure infra — needs `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` repo variables and `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` / `ALERT_EMAIL` repo secrets configured first; see `infra/azure/README.md`)