### PR TITLE
fix(bindings): bindings/main missing from the Docker build context

### DIFF
--- a/bindings/Dockerfile.build.dockerignore
+++ b/bindings/Dockerfile.build.dockerignore
@@ -1,0 +1,61 @@
+# Sidecar ignore file for bindings/Dockerfile.build, which BuildKit picks up
+# instead of the repo-root .dockerignore for this specific -f target. The
+# root .dockerignore excludes bindings/ (correct for the main app image,
+# which has no business bundling foreign-language binding source), but this
+# Dockerfile's whole job is building those bindings, so it needs the
+# opposite: everything the root ignore excludes EXCEPT bindings/ itself.
+
+# Version control and editor
+.git
+.github
+.venv
+.vscode
+.idea
+
+# Build caches and dependencies
+node_modules
+dist
+build
+vendor/
+.cache/
+*.egg-info
+__pycache__
+
+# Web frontend (still irrelevant to the bindings build)
+sop-arena/
+
+# Documentation and assets (preserve embedded prompt templates)
+docs/
+*.md
+!ai/agent/prompts/*.md
+_config.yml
+
+# Test and coverage artifacts
+*.test
+*.out
+*.log
+*.cov
+coverage/
+*.so
+*.dylib
+*.dll
+*.a
+
+# Generated binaries
+/httpserver
+/httpserver_test
+/main
+/server
+/sop_server
+tools/httpserver/httpserver
+tools/httpserver/sop_server
+
+# Data directories and runtime logs
+data/
+translogs/
+storelist.txt
+ai/data/
+ai/nurse_output.txt
+ai/storelist.txt
+tools/httpserver/data_browser
+tools/httpserver/sop-browser


### PR DESCRIPTION
## Summary

While watching the `v5.5.0` release run, `Build Native (Linux & Windows)` failed with:

```
/bin/bash: line 1: cd: bindings/main: No such file or directory
```

Root cause: `bindings/Dockerfile.build`'s final `COPY --chown=sop:sop . .` is filtered by the repo-root `.dockerignore`, which excludes `bindings/` entirely - correct for the main app image (`Dockerfile`), which has no business bundling foreign-language binding source, but wrong for this Dockerfile, whose entire job is building those bindings. `bindings/main` (and the rest of `bindings/`) never made it into the image.

**Confirmed pre-existing**: `v5.4.0`'s `release.yml` run failed the identical way, so this isn't a regression from anything in this branch - it's a standing bug that's been silently breaking the native binary build (and therefore the `Create Release` step, which needs those artifacts) on every tagged release.

## Fix

Added `bindings/Dockerfile.build.dockerignore`, a sidecar ignore file that BuildKit picks up automatically for this specific `-f bindings/Dockerfile.build` target instead of the root one. It's the root file's exclusions minus the `bindings/` line.

## Test plan

- [x] `DOCKER_BUILDKIT=1 docker build -t sop-bindings-builder-test -f bindings/Dockerfile.build .` - succeeds
- [x] `docker run --rm sop-bindings-builder-test ls bindings/main/` - `bindings/main/build.sh` and its Go sources are now present
- [ ] CI: ci.yml / go.yml / security.yml / codeql.yml / e2e.yml